### PR TITLE
HTTP hook on_close modification. Fixes for Mac OS X and CherryPy installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@
 /trunk/research/api-server/static-dir/forward
 /trunk/research/api-server/static-dir/live
 /trunk/research/api-server/static-dir/players
+
+# Apple-specific garbage files.
+.AppleDouble

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -231,65 +231,56 @@ function OSX_prepare()
     
     gcc --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
         echo "install gcc"
-        require_sudoer "sudo brew install gcc"
-        sudo brew install gcc; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+        brew install gcc; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
         echo "install gcc success"
     fi
     
     g++ --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
         echo "install gcc-c++"
-        require_sudoer "sudo brew install gcc-c++"
-        sudo brew install gcc-c++; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+        brew install gcc-c++; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
         echo "install gcc-c++ success"
     fi
     
     make --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
         echo "install make"
-        require_sudoer "sudo brew install make"
-        sudo brew install make; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+        brew install make; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
         echo "install make success"
     fi
     
     patch --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
         echo "install patch"
-        require_sudoer "sudo brew install patch"
-        sudo brew install patch; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+        brew install patch; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
         echo "install patch success"
     fi
     
     if [ $SRS_FFMPEG_TOOL = YES ]; then
         automake --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
             echo "install automake"
-            require_sudoer "sudo brew install automake"
-            sudo brew install automake; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+            brew install automake; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
             echo "install automake success"
         fi
         
         autoconf --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
             echo "install autoconf"
-            require_sudoer "sudo brew install autoconf"
-            sudo brew install autoconf; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+            brew install autoconf; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
             echo "install autoconf success"
         fi
         
         libtool --help >/dev/null 2>&1; ret=$?; if [[ 0 -ne $ret ]]; then
             echo "install libtool"
-            require_sudoer "sudo brew install libtool"
-            sudo brew install libtool; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+            brew install libtool; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
             echo "install libtool success"
         fi
         
         if [[ ! -f /usr/include/pcre.h ]]; then
             echo "install pcre-devel"
-            require_sudoer "sudo brew install pcre-devel"
-            sudo brew install pcre-devel; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+            brew install pcre-devel; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
             echo "install pcre-devel success"
         fi
         
         if [[ ! -f /usr/include/zlib.h ]]; then
             echo "install zlib-devel"
-            require_sudoer "sudo brew install zlib-devel"
-            sudo brew install zlib-devel; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
+            brew install zlib-devel; ret=$?; if [[ 0 -ne $ret ]]; then return $ret; fi
             echo "install zlib-devel success"
         fi
     fi

--- a/trunk/configure
+++ b/trunk/configure
@@ -9,10 +9,10 @@ mkdir -p ${SRS_OBJS}
 
 #####################################################################################
 # linux shell color support.
-RED="\\e[31m"
-GREEN="\\e[32m"
-YELLOW="\\e[33m"
-BLACK="\\e[0m"
+RED="\\033[31m"
+GREEN="\\033[32m"
+YELLOW="\\033[33m"
+BLACK="\\033[0m"
 
 #####################################################################################
 # parse user options, set the variables like:

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -95,7 +95,7 @@ int SrsHttpHooks::on_connect(string url, int client_id, string ip, SrsRequest* r
     return ret;
 }
 
-void SrsHttpHooks::on_close(string url, int client_id, string ip, SrsRequest* req)
+void SrsHttpHooks::on_close(string url, int client_id, string ip, SrsRequest* req, int64_t send_bytes, int64_t recv_bytes)
 {
     int ret = ERROR_SUCCESS;
     
@@ -112,6 +112,8 @@ void SrsHttpHooks::on_close(string url, int client_id, string ip, SrsRequest* re
         << __SRS_JFIELD_ORG("client_id", client_id) << __SRS_JFIELD_CONT
         << __SRS_JFIELD_STR("ip", ip) << __SRS_JFIELD_CONT
         << __SRS_JFIELD_STR("vhost", req->vhost) << __SRS_JFIELD_CONT
+        << __SRS_JFIELD_ORG("send_bytes", send_bytes) << __SRS_JFIELD_CONT
+        << __SRS_JFIELD_ORG("recv_bytes", recv_bytes) << __SRS_JFIELD_CONT
         << __SRS_JFIELD_STR("app", req->app)
         << __SRS_JOBJECT_END;
     std::string data = ss.str();

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -67,7 +67,7 @@ public:
     * @param url the api server url, to process the event. 
     *         ignore if empty.
     */
-    static void on_close(std::string url, int client_id, std::string ip, SrsRequest* req);
+    static void on_close(std::string url, int client_id, std::string ip, SrsRequest* req, int64_t send_bytes, int64_t recv_bytes);
     /**
     * on_publish hook, when client(encoder) start to publish stream
     * @param client_id the id of client on server.

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -1096,7 +1096,7 @@ void SrsRtmpConn::http_hooks_on_close()
         int connection_id = _srs_context->get_id();
         for (int i = 0; i < (int)on_close->args.size(); i++) {
             std::string url = on_close->args.at(i);
-            SrsHttpHooks::on_close(url, connection_id, ip, req);
+            SrsHttpHooks::on_close(url, connection_id, ip, req, skt->get_send_bytes(), skt->get_recv_bytes());
         }
     }
 #endif

--- a/trunk/src/app/srs_app_st.cpp
+++ b/trunk/src/app/srs_app_st.cpp
@@ -26,7 +26,10 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <srs_kernel_error.hpp>
 #include <srs_kernel_log.hpp>
 
+#ifdef __linux__
 #include <sys/epoll.h>
+
+
 bool srs_st_epoll_is_supported(void)
 {
     struct epoll_event ev;
@@ -38,27 +41,31 @@ bool srs_st_epoll_is_supported(void)
 
     return (errno != ENOSYS);
 }
+#endif
 
 int srs_init_st()
 {
     int ret = ERROR_SUCCESS;
     
+#ifdef __linux__
     // check epoll, some old linux donot support epoll.
     // @see https://github.com/winlinvip/simple-rtmp-server/issues/162
     if (!srs_st_epoll_is_supported()) {
         ret = ERROR_ST_SET_EPOLL;
-        srs_error("epoll required. ret=%d", ret);
+        srs_error("epoll required on Linux. ret=%d", ret);
         return ret;
     }
+#endif
     
-    // use linux epoll.
+    // Select the best event system available on the OS. In Linux this is
+    // epoll(). On BSD it will be kqueue.
     if (st_set_eventsys(ST_EVENTSYS_ALT) == -1) {
         ret = ERROR_ST_SET_EPOLL;
-        srs_error("st_set_eventsys use linux epoll failed. ret=%d", ret);
+        srs_error("st_set_eventsys use %s failed. ret=%d", st_get_eventsys_name(), ret);
         return ret;
     }
-    srs_verbose("st_set_eventsys use linux epoll success");
-    
+    srs_verbose("st_set_eventsys use %s success", st_get_eventsys_name());
+
     if(st_init() != 0){
         ret = ERROR_ST_INITIALIZE;
         srs_error("st_init failed. ret=%d", ret);


### PR DESCRIPTION
These set of commits fixes some of the issues I found while trying to build on Mac OS X and also modifies `on_close` HTTP hook.

CherryPy installation process blindly tries to install CherryPy using sudo. On systems that have virtualenv, sudo is not required. Blindly installing CherryPy will also clobber existing installations. I made a few changes to the procedure so that:

1. We check to see if we can `import cherrypy`. If we can do this then there is no need to install it.
2. If we need to install CherryPy, we first check if the `python` binary is in a virtualenv. We don't use sudo if this is the case. We check to see if we have homebrew. We don't use sudo for homebrew installations too.
3. Prompt the user if they indeed want to install CherryPy. In this way, the user has the option to cancel and manually install CherryPy in the correct location.

`on_close` HTTP hook is modified so that it receives bytes send and received for the duration of the connection. This is to allow for systems that want to track bandwidth usage. This is only a minor change and does not affect the current existing HTTP hooks that don't use these fields.

I also fixed output colorization on Mac OS X. Somehow, Mac OS X does not like `\e`.

Linux-specific `#include <sys/epoll.h>` along with the sections of code that use them is now isolated and ignored if we are not building on Linux.

Finally, installing dependencies on Mac OS X using homebrew does not require sudo anymore so they are removed in this patch as well. I am not quite sure if installing `gcc` and `g++` is necessary. The better solution would be to check for the existing XCode installation, but I cannot test that sort of changes.