### PR TITLE
HTTP hook on_close modification. Fixes for Mac OS X and CherryPy installation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 /trunk/research/api-server/static-dir/forward
 /trunk/research/api-server/static-dir/live
 /trunk/research/api-server/static-dir/players
+
+# Apple-specific garbage files.
+.AppleDouble

--- a/README.md
+++ b/README.md
@@ -674,6 +674,7 @@ Supported operating systems and hardware:
 * v1.0, 2015-01-01, hotfix [#270](https://github.com/winlinvip/simple-rtmp-server/issues/270), memory leak for http client post. 1.0.16
 * v1.0, 2014-12-29, hotfix [#267](https://github.com/winlinvip/simple-rtmp-server/issues/267), the forward dest ep should use server. 1.0.15
 * v1.0, 2014-12-29, hotfix [#268](https://github.com/winlinvip/simple-rtmp-server/issues/268), the hls pcr is negative when startup. 1.0.14
+* v1.0, 2014-12-26, use master as main stable branch with hotfixes. 1.0.13
 * v1.0, 2014-12-22, hotfix [#264](https://github.com/winlinvip/simple-rtmp-server/issues/264), ignore NALU when sequence header to make HLS happy. 1.0.12
 * v1.0, 2014-12-20, hotfix [#264](https://github.com/winlinvip/simple-rtmp-server/issues/264), support disconnect publish connect when hls error. 1.0.11
 * <strong>v1.0, 2014-12-05, [1.0 release(1.0.10)](https://github.com/winlinvip/simple-rtmp-server/releases/tag/1.0) released. 59391 lines.</strong>

--- a/trunk/auto/depends.sh
+++ b/trunk/auto/depends.sh
@@ -537,16 +537,64 @@ fi
 # cherrypy for http hooks callback, CherryPy-3.2.4
 #####################################################################################
 if [ $SRS_HTTP_CALLBACK = YES ]; then
+    echo "HTTP callbacks enabled. Checking for CherryPy..."
     if [[ -f ${SRS_OBJS}/CherryPy-3.2.4/setup.py ]]; then
         echo "CherryPy-3.2.4 is ok.";
     else
-        require_sudoer "install CherryPy-3.2.4"
-        echo "install CherryPy-3.2.4"; 
-        (
-            sudo rm -rf ${SRS_OBJS}/CherryPy-3.2.4 && cd ${SRS_OBJS} && 
-            unzip -q ../3rdparty/CherryPy-3.2.4.zip && cd CherryPy-3.2.4 && 
-            sudo python setup.py install
-        )
+        echo "Checking Python environment..."
+        SRS_PYTHON_BINARY=`which python`
+        if [ "x${SRS_PYTHON_BINARY}" = "x" ]; then
+            echo "You do not have Python installed or it is not in your PATH."
+            echo "Please ensure that you have a usable Python before continuing."
+            exit 1
+        fi
+
+        ${SRS_PYTHON_BINARY} -c 'import cherrypy' >/dev/null 2>&1
+        if [ $? -eq 1 ]; then
+            if [ "x${VIRTUAL_ENV}" = "x" ]; then
+                echo "Not running in a virtualenv."
+                echo "Using Python found in ${SRS_PYTHON_BINARY}"
+                if [ "/usr/bin/python" = "${SRS_PYTHON_BINARY}" ]; then
+                    require_sudoer "configure --with-http-callback"
+                    SRS_PYTHON_CMD="sudo $SRS_PYTHON_BINARY"
+                    SRS_CLEAN_CHERRYPY="sudo rm -rf"
+                else
+                    if [ -x /usr/local/bin/brew ]; then
+                        SRS_PYTHON_CMD="$SRS_PYTHON_BINARY"
+                        SRS_CLEAN_CHERRYPY="rm -rf"
+                        echo "Your current Python is *probably* installed using homebrew."
+                    else
+                        SRS_PYTHON_CMD="sudo $SRS_PYTHON_BINARY"
+                        SRS_CLEAN_CHERRYPY="sudo rm -rf"
+                        echo "Your current Python is installed from source. Or MacPorts."
+                    fi
+                fi
+            else
+                echo "Running in virtualenv: ${VIRTUAL_ENV}"
+                SRS_PYTHON_CMD="$VIRTUAL_ENV/bin/python"
+                SRS_CLEAN_CHERRYPY="rm -rf"
+            fi
+
+            read -p "Do you want to install CherryPy in your current Python environment (yes/no)? " SRS_CONFIRMATION
+            case "${SRS_CONFIRMATION}" in
+                yes|YES)
+                    echo "Installing CherryPy..."
+                    ;;
+                *)
+                    echo "CherryPy installation cancelled. Install CherryPy manually before proceeding."
+                    exit 1
+                    ;;
+            esac
+
+            echo "install CherryPy-3.2.4"; 
+            (
+                ${SRS_CLEAN_CHERRYPY} ${SRS_OBJS}/CherryPy-3.2.4 && cd ${SRS_OBJS} && 
+                unzip -q ../3rdparty/CherryPy-3.2.4.zip && cd CherryPy-3.2.4 && 
+                ${SRS_PYTHON_CMD} setup.py install
+            )
+        else
+            echo "CherryPy is already installed."
+        fi
     fi
     # check status
     ret=$?; if [[ $ret -ne 0 ]]; then echo "build CherryPy-3.2.4 failed, ret=$ret"; exit $ret; fi

--- a/trunk/src/app/srs_app_http_hooks.cpp
+++ b/trunk/src/app/srs_app_http_hooks.cpp
@@ -82,7 +82,7 @@ int SrsHttpHooks::on_connect(string url, int client_id, string ip, SrsRequest* r
     return ret;
 }
 
-void SrsHttpHooks::on_close(string url, int client_id, string ip, SrsRequest* req)
+void SrsHttpHooks::on_close(string url, int client_id, string ip, SrsRequest* req, int64_t send_bytes, int64_t recv_bytes)
 {
     int ret = ERROR_SUCCESS;
     
@@ -92,6 +92,8 @@ void SrsHttpHooks::on_close(string url, int client_id, string ip, SrsRequest* re
         << __SRS_JFIELD_ORG("client_id", client_id) << __SRS_JFIELD_CONT
         << __SRS_JFIELD_STR("ip", ip) << __SRS_JFIELD_CONT
         << __SRS_JFIELD_STR("vhost", req->vhost) << __SRS_JFIELD_CONT
+        << __SRS_JFIELD_ORG("send_bytes", send_bytes) << __SRS_JFIELD_CONT
+        << __SRS_JFIELD_ORG("recv_bytes", recv_bytes) << __SRS_JFIELD_CONT
         << __SRS_JFIELD_STR("app", req->app)
         << __SRS_JOBJECT_END;
         

--- a/trunk/src/app/srs_app_http_hooks.hpp
+++ b/trunk/src/app/srs_app_http_hooks.hpp
@@ -66,7 +66,7 @@ public:
     * @param url the api server url, to process the event. 
     *         ignore if empty.
     */
-    static void on_close(std::string url, int client_id, std::string ip, SrsRequest* req);
+    static void on_close(std::string url, int client_id, std::string ip, SrsRequest* req, int64_t send_bytes, int64_t recv_bytes);
     /**
     * on_publish hook, when client(encoder) start to publish stream
     * @param client_id the id of client on server.

--- a/trunk/src/app/srs_app_rtmp_conn.cpp
+++ b/trunk/src/app/srs_app_rtmp_conn.cpp
@@ -1294,7 +1294,7 @@ void SrsRtmpConn::http_hooks_on_close()
         int connection_id = _srs_context->get_id();
         for (int i = 0; i < (int)on_close->args.size(); i++) {
             std::string url = on_close->args.at(i);
-            SrsHttpHooks::on_close(url, connection_id, ip, req);
+            SrsHttpHooks::on_close(url, connection_id, ip, req, skt->get_send_bytes(), skt->get_recv_bytes());
         }
     }
 #endif

--- a/trunk/src/app/srs_app_st.cpp
+++ b/trunk/src/app/srs_app_st.cpp
@@ -28,6 +28,8 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #ifndef SRS_OSX
 #include <sys/epoll.h>
+
+
 bool srs_st_epoll_is_supported(void)
 {
     struct epoll_event ev;
@@ -50,14 +52,15 @@ int srs_init_st()
     // @see https://github.com/winlinvip/simple-rtmp-server/issues/162
     if (!srs_st_epoll_is_supported()) {
         ret = ERROR_ST_SET_EPOLL;
-        srs_error("epoll required. ret=%d", ret);
+        srs_error("epoll required on Linux. ret=%d", ret);
         return ret;
     }
     
-    // use linux epoll.
+    // Select the best event system available on the OS. In Linux this is
+    // epoll(). On BSD it will be kqueue.
     if (st_set_eventsys(ST_EVENTSYS_ALT) == -1) {
         ret = ERROR_ST_SET_EPOLL;
-        srs_error("st_set_eventsys use linux epoll failed. ret=%d", ret);
+        srs_error("st_set_eventsys use %s failed. ret=%d", st_get_eventsys_name(), ret);
         return ret;
     }
     srs_verbose("st_set_eventsys use linux epoll success");


### PR DESCRIPTION
Merged from my local master into develop branch as advised from my previous pull request. Copying relevant parts of the description here:

These set of commits fixes some of the issues I found while trying to build on Mac OS X and also modifies on_close HTTP hook.

CherryPy installation process blindly tries to install CherryPy using sudo. On systems that have virtualenv, sudo is not required. Blindly installing CherryPy will also clobber existing installations. I made a few changes to the procedure so that:

We check to see if we can import cherrypy. If we can do this then there is no need to install it.
If we need to install CherryPy, we first check if the python binary is in a virtualenv. We don't use sudo if this is the case. We check to see if we have homebrew. We don't use sudo for homebrew installations too.
Prompt the user if they indeed want to install CherryPy. In this way, the user has the option to cancel and manually install CherryPy in the correct location.

on_close HTTP hook is modified so that it receives bytes send and received for the duration of the connection. This is to allow for systems that want to track bandwidth usage. This is only a minor change and does not affect the current existing HTTP hooks that don't use these fields. **NB:** I just found out there is already bandwidth usage statistics in the HTTP management API. However, for our use case, we need this management API turned off but we still need the usage statistics. Since bytes send and received is already being tracked per connection anyway, I just modify on_close to add these two to the HTTP hook parameters.

Also fixed output colorization on Mac OS X. Somehow, Mac OS X Bash does not support \e.